### PR TITLE
Store the `githubUser` prompt

### DIFF
--- a/repo/index.js
+++ b/repo/index.js
@@ -72,6 +72,7 @@ var RepoGenerator = yeoman.generators.Base.extend({
         }, {
             name: 'githubUser',
             message: 'What\'s your GitHub username?',
+            store: true,
             default: 'my-user'
         }, {
             name: 'elementName',


### PR DESCRIPTION
So I don't have to type it over and over. Why not?